### PR TITLE
Resize words on both sides, enhanced file dialog for export to MOHO .dat 

### DIFF
--- a/LipsyncFrameQT.py
+++ b/LipsyncFrameQT.py
@@ -658,7 +658,7 @@ class LipsyncFrame:
             wildcard = ""
             if exporter == "MOHO":
                 message = "Export Lipsync Data (MOHO)"
-                default_file = "{}".format(self.doc.soundPath.rsplit('.', 1)[0])
+                default_file = "{}".format(self.doc.soundPath.rsplit('.', 1)[0]) + ".dat"
                 wildcard = "Moho switch files (*.dat)"
             elif exporter == "ALELO":
                 fps = int(self.config.value("FPS", 24))
@@ -692,11 +692,12 @@ class LipsyncFrame:
             file_path, _ = QtWidgets.QFileDialog.getSaveFileName(self.main_window,
                                                                  message,
                                                                  default_file,
-                                                                 wildcard)
+                                                                 wildcard,
+                                                                 options=QtWidgets.QFileDialog.DontUseNativeDialog)
             if file_path:
                 self.config.setValue("WorkingDir", os.path.dirname(file_path))
                 if exporter == "MOHO":
-                    self.doc.current_voice.export(file_path)
+                    self.doc.current_voice.export(file_path if ("." in file_path) else file_path + ".dat")
                 elif exporter == "ALELO":
                     self.doc.current_voice.export_alelo(file_path, language, self.langman)
                 elif exporter == "Images":

--- a/LipsyncFrameQT.py
+++ b/LipsyncFrameQT.py
@@ -658,8 +658,8 @@ class LipsyncFrame:
             wildcard = ""
             if exporter == "MOHO":
                 message = "Export Lipsync Data (MOHO)"
-                default_file = "{}".format(self.doc.soundPath.rsplit('.', 1)[0]) + ".dat"
-                wildcard = "Moho switch files (*.dat)|*.dat"
+                default_file = "{}".format(self.doc.soundPath.rsplit('.', 1)[0])
+                wildcard = "Moho switch files (*.dat)"
             elif exporter == "ALELO":
                 fps = int(self.config.value("FPS", 24))
                 if fps != 100:
@@ -691,7 +691,7 @@ class LipsyncFrame:
                 wildcard = "JSON object files (*.json)|*.json"
             file_path, _ = QtWidgets.QFileDialog.getSaveFileName(self.main_window,
                                                                  message,
-                                                                 self.config.value("WorkingDir", get_main_dir()),
+                                                                 default_file,
                                                                  wildcard)
             if file_path:
                 self.config.setValue("WorkingDir", os.path.dirname(file_path))

--- a/LipsyncFrameQT.py
+++ b/LipsyncFrameQT.py
@@ -335,8 +335,8 @@ class LipsyncFrame:
         num_frames = wfv.waveform_polygon.polygon().boundingRect().width() / wfv.frame_width
         frames_per_top_level = num_frames / len(top_nodes)
         for num, top_node in enumerate(top_nodes):
-            top_node.name.lipsync_object.start_frame = (num * frames_per_top_level) + int(bool(num))
-            top_node.name.lipsync_object.end_frame = (num * frames_per_top_level) + frames_per_top_level
+            top_node.name.lipsync_object.start_frame = round((num * frames_per_top_level) + int(bool(num)))
+            top_node.name.lipsync_object.end_frame = round((num * frames_per_top_level) + frames_per_top_level)
             top_node.name.after_reposition()
             top_node.name.reposition_descendants2(True)
             

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -277,16 +277,9 @@ class MovableButton(QtWidgets.QPushButton):
                 else:
                     self.is_resizing = False
                     self.is_moving = True
-                # print("resize origin: " + str(self.resize_origin))
             else:
                 self.is_moving = True
             if self.is_resizing and not self.is_moving:
-                # whatsup = "\nleft max: " + str(self.get_left_max()) + " ,right max: " + str(self.get_right_max())
-                # whatsup += " start frame: " + str(self.lipsync_object.start_frame) + " , end frame: " + str(self.lipsync_object.end_frame)
-                # whatsup += " min size: " + str(self.get_min_size()) + " frame size: " + str(self.get_frame_size())
-                # whatsup += " self x: " + str(self.x()) + " , event x: " + str(event.x())
-                # print (whatsup)
-
                 self.wfv_parent.doc.dirty = True
                 self.after_reposition()
                 if self.resize_origin == 1:  # start resize from right side

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -60,6 +60,7 @@ font = QtGui.QFont("Swiss", 6)
 default_sample_width = 4
 default_samples_per_frame = 2
 
+resize_handle_width = 2
 
 class SceneWithDrag(QtWidgets.QGraphicsScene):
     def dragEnterEvent(self, e):
@@ -127,11 +128,12 @@ class MovableButton(QtWidgets.QPushButton):
                     phrase_fill_col.red(),
                     phrase_fill_col.green(),
                     phrase_fill_col.blue())
-                self.style += "background-image: url(:/rsrc/marker.png); "
-                self.style += "background-repeat: repeat-y; background-position: right;"
-                self.style += "border:1px solid rgb({0},{1},{2});}};".format(phrase_outline_col.red(),
+                # self.style += "background-image: url(:/rsrc/marker.png); "
+                # self.style += "background-repeat: repeat-y; background-position: right;"
+                self.style += "border:1px solid rgb({0},{1},{2});".format(phrase_outline_col.red(),
                                                                              phrase_outline_col.green(),
                                                                              phrase_outline_col.blue())
+                self.style +=  "border-width: 1px {0};}};" .format(self.convert_to_pixels(resize_handle_width))
                 # self.style = """QPushButton {
                 #                 color: #000000;
                 #                 border-image: url(./rsrc/testbutton2.png) 2 10 2 2 repeat;
@@ -147,9 +149,10 @@ class MovableButton(QtWidgets.QPushButton):
                     word_fill_col.blue())
                 # self.style += "background-image: url(:/rsrc/marker.png); "
                 # self.style += "background-repeat: repeat-y; background-position: right;"
-                self.style += "border:1px solid rgb({0},{1},{2});}};".format(word_outline_col.red(),
-                                                                             word_outline_col.green(),
-                                                                             word_outline_col.blue())
+                self.style += "border: 1px solid rgb({0},{1},{2});".format(word_outline_col.red(),
+                                                                            word_outline_col.green(),
+                                                                            word_outline_col.blue())
+                self.style +=  "border-width: 1px {0};}};" .format(self.convert_to_pixels(resize_handle_width))
             elif self.is_phoneme():
                 self.style = "QPushButton {{color: #000000; background-color:rgb({0},{1},{2});".format(
                     phoneme_fill_col.red(),
@@ -278,11 +281,11 @@ class MovableButton(QtWidgets.QPushButton):
             if event.buttons() == QtCore.Qt.LeftButton:
                 if not self.is_phoneme():
                     # print(str(round(self.convert_to_frames(self.x()))) + " - "  + str(self.lipsync_object.end_frame) + " / " + str(round(self.convert_to_frames(self.x() + event.x()))))
-                    if (round(self.convert_to_frames(
-                            self.x() + event.x())) >= self.lipsync_object.end_frame - 2 ) and not self.is_moving:
+                    if (math.floor(self.convert_to_frames(
+                            self.x() + event.x())) >= self.lipsync_object.end_frame - resize_handle_width ) and not self.is_moving:
                         self.is_resizing = True
                         self.resize_origin = 1
-                    if ( self.convert_to_frames(self.x() + event.x()) <= self.convert_to_frames(self.x()) + 2 ):       
+                    if ( math.ceil(self.convert_to_frames(self.x() + event.x())) <= round(self.convert_to_frames(self.x()) + resize_handle_width )):       
                         self.is_resizing = True
                         self.resize_origin = 0
                 else:

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -128,27 +128,15 @@ class MovableButton(QtWidgets.QPushButton):
                     phrase_fill_col.red(),
                     phrase_fill_col.green(),
                     phrase_fill_col.blue())
-                # self.style += "background-image: url(:/rsrc/marker.png); "
-                # self.style += "background-repeat: repeat-y; background-position: right;"
                 self.style += "border:1px solid rgb({0},{1},{2});".format(phrase_outline_col.red(),
                                                                              phrase_outline_col.green(),
                                                                              phrase_outline_col.blue())
                 self.style +=  "border-width: 1px {0};}};" .format(self.convert_to_pixels(resize_handle_width))
-                # self.style = """QPushButton {
-                #                 color: #000000;
-                #                 border-image: url(./rsrc/testbutton2.png) 2 10 2 2 repeat;
-                #                 border-top: 2px transparent;
-                #                 border-bottom: 2px transparent;
-                #                 border-right: 10px transparent;
-                #                 border-left: 2px transparent;
-                #                 }"""
             elif self.is_word():
                 self.style = "QPushButton {{color: #000000; background-color:rgb({0},{1},{2});".format(
                     word_fill_col.red(),
                     word_fill_col.green(),
                     word_fill_col.blue())
-                # self.style += "background-image: url(:/rsrc/marker.png); "
-                # self.style += "background-repeat: repeat-y; background-position: right;"
                 self.style += "border: 1px solid rgb({0},{1},{2});".format(word_outline_col.red(),
                                                                             word_outline_col.green(),
                                                                             word_outline_col.blue())
@@ -280,7 +268,6 @@ class MovableButton(QtWidgets.QPushButton):
         if not self.wfv_parent.doc.sound.is_playing():
             if event.buttons() == QtCore.Qt.LeftButton:
                 if not self.is_phoneme():
-                    # print(str(round(self.convert_to_frames(self.x()))) + " - "  + str(self.lipsync_object.end_frame) + " / " + str(round(self.convert_to_frames(self.x() + event.x()))))
                     if (math.floor(self.convert_to_frames(
                             self.x() + event.x())) >= self.lipsync_object.end_frame - resize_handle_width ) and not self.is_moving:
                         self.is_resizing = True

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -287,7 +287,7 @@ class MovableButton(QtWidgets.QPushButton):
                 self.after_reposition()
                 if self.resize_origin == 1:  # start resize from right side
                     if round(self.convert_to_frames(
-                            event.x() + self.x())) + 1 >= self.lipsync_object.start_frame + self.get_min_size():
+                            event.x() + self.x())) >= self.lipsync_object.start_frame + self.get_min_size():
                         if round(self.convert_to_frames(event.x() + self.x())) + 1 <= self.get_right_max():
                             self.lipsync_object.end_frame = math.floor(self.convert_to_frames(event.x() + self.x())) + 1
                             self.wfv_parent.doc.dirty = True

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -273,31 +273,21 @@ class MovableButton(QtWidgets.QPushButton):
                         self.resize_origin = 1
                     if (self.x() + event.x() <= self.x() + resize_handle_width ):       
                         self.is_resizing = True
-                        self.resize_origin = 0
+                        self.resize_origin = 0 
                 else:
                     self.is_resizing = False
                     self.is_moving = True
+                # print("resize origin: " + str(self.resize_origin))
             else:
                 self.is_moving = True
             if self.is_resizing and not self.is_moving:
-                print("left max: " + str(self.get_left_max()) + " ,right max: " + str(self.get_right_max()))
-                print("start frame: " + str(self.lipsync_object.start_frame) + " , end frame: " + str(self.lipsync_object.end_frame))
-                print("min size: " + str(self.get_min_size()) + " frame size: " + str(self.get_frame_size()))
-                print("self x: " + str(self.x()) + " , event x: " + str(event.x()))
-                if self.get_frame_size() < self.get_min_size():
-                    if self.resize_origin == 1:
-                        if self.get_right_max() - self.lipsync_object.start_frame > self.get_min_size():
-                            self.lipsync_object.end_frame = self.lipsync_object.start_frame + self.get_min_size()
-                        else:
-                            self.lipsync_object.start_frame = self.get_right_max() - self.get_min_size()
-                    elif self.resize_origin == 0:
-                        if self.lipsync_object.start_frame - self.get_left_max() > self.get_min_size():
-                            self.lipsync_object.start_frame = self.lipsync_object.end_frame - self.get_min_size()
-                        else:
-                            self.lipsync_object.start_frame = self.get_left_max() 
-                            self.lipsync_object.end_frame += self.get_min_size()
-                     
-                    self.wfv_parent.doc.dirty = True
+                # whatsup = "\nleft max: " + str(self.get_left_max()) + " ,right max: " + str(self.get_right_max())
+                # whatsup += " start frame: " + str(self.lipsync_object.start_frame) + " , end frame: " + str(self.lipsync_object.end_frame)
+                # whatsup += " min size: " + str(self.get_min_size()) + " frame size: " + str(self.get_frame_size())
+                # whatsup += " self x: " + str(self.x()) + " , event x: " + str(event.x())
+                # print (whatsup)
+
+                self.wfv_parent.doc.dirty = True
                 self.after_reposition()
                 if self.resize_origin == 1:  # start resize from right side
                     if round(self.convert_to_frames(
@@ -308,9 +298,11 @@ class MovableButton(QtWidgets.QPushButton):
                             self.resize(self.convert_to_pixels(self.lipsync_object.end_frame) -
                                         self.convert_to_pixels(self.lipsync_object.start_frame), self.height())
                 elif self.resize_origin == 0:  # start resize from left side
-                    if round(self.convert_to_frames(event.x() + self.x())) < self.lipsync_object.end_frame:
+                    if round(self.convert_to_frames(event.x() + self.x())) < self.lipsync_object.end_frame - 1:
                         if round(self.convert_to_frames(event.x() + self.x())) >= self.get_left_max():
                             self.lipsync_object.start_frame = round(self.convert_to_frames(event.x() + self.x()))
+                            if self.get_frame_size() < self.get_min_size():
+                                self.lipsync_object.start_frame = self.lipsync_object.end_frame - self.get_min_size()
                             new_length = self.convert_to_pixels(self.lipsync_object.end_frame) - self.convert_to_pixels(self.lipsync_object.start_frame)
                             self.resize(new_length, self.height())
                             self.move(self.convert_to_pixels(self.lipsync_object.start_frame), self.y())

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -128,19 +128,19 @@ class MovableButton(QtWidgets.QPushButton):
                     phrase_fill_col.red(),
                     phrase_fill_col.green(),
                     phrase_fill_col.blue())
-                self.style += "border:1px solid rgb({0},{1},{2});".format(phrase_outline_col.red(),
+                self.style += "border-color: rgb({0},{1},{2});".format(phrase_outline_col.red(),
                                                                              phrase_outline_col.green(),
                                                                              phrase_outline_col.blue())
-                self.style +=  "border-width: 1px {0};}};" .format(self.convert_to_pixels(resize_handle_width))
+                self.style +=  "border-style: solid solid solid solid; border-width: 1px {0}px}};" .format(self.convert_to_pixels(resize_handle_width))
             elif self.is_word():
                 self.style = "QPushButton {{color: #000000; background-color:rgb({0},{1},{2});".format(
                     word_fill_col.red(),
                     word_fill_col.green(),
                     word_fill_col.blue())
-                self.style += "border: 1px solid rgb({0},{1},{2});".format(word_outline_col.red(),
+                self.style += "border-color: rgb({0},{1},{2});".format(word_outline_col.red(),
                                                                             word_outline_col.green(),
                                                                             word_outline_col.blue())
-                self.style +=  "border-width: 1px {0};}};" .format(self.convert_to_pixels(resize_handle_width))
+                self.style +=  "border-style: solid solid solid solid; border-width: 1px {0}px}};" .format(self.convert_to_pixels(resize_handle_width))
             elif self.is_phoneme():
                 self.style = "QPushButton {{color: #000000; background-color:rgb({0},{1},{2});".format(
                     phoneme_fill_col.red(),
@@ -406,10 +406,10 @@ class MovableButton(QtWidgets.QPushButton):
         # Change the border-style or something like that depending on whether there are tags or not
         if len(self.lipsync_object.tags) > 0:
             if "solid" in self.styleSheet():
-                self.setStyleSheet(self.styleSheet().replace("solid", "dashed "))
+                self.setStyleSheet(self.styleSheet().replace("solid solid solid solid", "dashed double dashed double"))
         else:
-            if "dashed " in self.styleSheet():
-                self.setStyleSheet(self.styleSheet().replace("dashed ", "solid"))
+            if "dashed" in self.styleSheet():
+                self.setStyleSheet(self.styleSheet().replace("dashed double dashed double", "solid solid solid solid"))
 
     def reposition_descendants(self, did_resize=False, x_diff=0):
         if did_resize:

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -26,6 +26,7 @@ import PySide2.QtGui as QtGui
 import PySide2.QtWidgets as QtWidgets
 import anytree.util
 import numpy as np
+import re
 from anytree import Node
 
 from LipsyncDoc import *
@@ -188,6 +189,10 @@ class MovableButton(QtWidgets.QPushButton):
         else:
             self.setGeometry(self.convert_to_pixels(self.lipsync_object.start_frame), self.y(),
                              self.convert_to_pixels(self.get_frame_size()), self.height())
+        # self.setStyleSheet(self.styleSheet().replace("19px", str(int(self.wfv_parent.frame_width)) + "px"))
+        replaced = re.sub('\d+px}', str(int(self.wfv_parent.frame_width)) + 'px}' , self.styleSheet())
+        # print(replaced)
+        self.setStyleSheet(replaced)
         self.update()
 
     def get_min_size(self):
@@ -268,10 +273,10 @@ class MovableButton(QtWidgets.QPushButton):
         if not self.wfv_parent.doc.sound.is_playing():
             if event.buttons() == QtCore.Qt.LeftButton:
                 if not self.is_phoneme():
-                    if (self.x() + event.x() >=  self.convert_to_pixels(self.lipsync_object.end_frame) - resize_handle_width ) and not self.is_moving:
+                    if (self.x() + event.x() >=  self.convert_to_pixels(self.lipsync_object.end_frame) - self.wfv_parent.frame_width ) and not self.is_moving:
                         self.is_resizing = True
                         self.resize_origin = 1
-                    if (self.x() + event.x() <= self.x() + resize_handle_width ):       
+                    if (self.x() + event.x() <= self.x() + self.wfv_parent.frame_width ):       
                         self.is_resizing = True
                         self.resize_origin = 0 
                 else:
@@ -1045,6 +1050,7 @@ class WaveformView(QtWidgets.QGraphicsView):
             self.samples_per_frame *= 2
             self.samples_per_sec = self.doc.fps * self.samples_per_frame
             self.frame_width = self.sample_width * self.samples_per_frame
+            # print(int(self.frame_width))
             for node in self.main_node.descendants:
                 node.name.after_reposition()
                 node.name.fit_text_to_size()

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -55,7 +55,6 @@ word_outline_col = QtGui.QColor(198, 121, 30)
 phoneme_fill_col = QtGui.QColor(231, 185, 210)
 phoneme_outline_col = QtGui.QColor(173, 114, 146)
 font = QtGui.QFont("Swiss", 6)
-font.setStyleHint(QtGui.QFont.Helvetica)
 
 # default_sample_width = 2
 # default_samples_per_frame = 4
@@ -287,14 +286,13 @@ class MovableButton(QtWidgets.QPushButton):
                 self.is_moving = True
             if self.is_resizing and not self.is_moving:
                 self.wfv_parent.doc.dirty = True
-                self.after_reposition()
                 if self.resize_origin == 1:  # start resize from right side
-                    if self.convert_to_frames(
-                            event.x() + self.x()) + 1 >= self.lipsync_object.start_frame + self.get_min_size():
+                    if round(self.convert_to_frames(
+                             event.x() + self.x())) >= self.lipsync_object.start_frame + self.get_min_size():
                         if self.convert_to_frames(event.x() + self.x()) <= self.get_right_max():
-                            self.lipsync_object.end_frame = math.floor(self.convert_to_frames(event.x() + self.x())) + 1
+                            self.lipsync_object.end_frame = math.ceil(self.convert_to_frames(event.x() + self.x()))
                             self.wfv_parent.doc.dirty = True
-                            self.resize(self.convert_to_pixels(self.lipsync_object.end_frame) -
+                            self.resize(self.convert_to_pixels(self.lipsync_object.end_frame) - 
                                         self.convert_to_pixels(self.lipsync_object.start_frame), self.height())
                 elif self.resize_origin == 0:  # start resize from left side
                     if self.convert_to_frames(event.x() + self.x()) < self.lipsync_object.end_frame:
@@ -305,6 +303,7 @@ class MovableButton(QtWidgets.QPushButton):
                             new_length = self.convert_to_pixels(self.lipsync_object.end_frame) - self.convert_to_pixels(self.lipsync_object.start_frame)
                             self.resize(new_length, self.height())
                             self.move(self.convert_to_pixels(self.lipsync_object.start_frame), self.y())
+                self.after_reposition()
             else:
                 self.is_moving = True
                 mime_data = QtCore.QMimeData()

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -191,7 +191,7 @@ class MovableButton(QtWidgets.QPushButton):
         else:
             self.setGeometry(self.convert_to_pixels(self.lipsync_object.start_frame), self.y(),
                              self.convert_to_pixels(self.get_frame_size()), self.height())
-        replaced = re.sub('(border-width: \dpx) \d+.*px', r'\1 {}px'.format(str(self.get_handle_width())), self.styleSheet())
+        replaced = re.sub('(border-width: \dpx) \d+px', r'\1 {}px'.format(str(self.get_handle_width())), self.styleSheet())
         self.setStyleSheet(replaced)
         self.update()
 

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -145,8 +145,8 @@ class MovableButton(QtWidgets.QPushButton):
                     word_fill_col.red(),
                     word_fill_col.green(),
                     word_fill_col.blue())
-                self.style += "background-image: url(:/rsrc/marker.png); "
-                self.style += "background-repeat: repeat-y; background-position: right;"
+                # self.style += "background-image: url(:/rsrc/marker.png); "
+                # self.style += "background-repeat: repeat-y; background-position: right;"
                 self.style += "border:1px solid rgb({0},{1},{2});}};".format(word_outline_col.red(),
                                                                              word_outline_col.green(),
                                                                              word_outline_col.blue())
@@ -277,10 +277,14 @@ class MovableButton(QtWidgets.QPushButton):
         if not self.wfv_parent.doc.sound.is_playing():
             if event.buttons() == QtCore.Qt.LeftButton:
                 if not self.is_phoneme():
+                    # print(str(round(self.convert_to_frames(self.x()))) + " - "  + str(self.lipsync_object.end_frame) + " / " + str(round(self.convert_to_frames(self.x() + event.x()))))
                     if (round(self.convert_to_frames(
-                            self.x() + event.x())) + 1 >= self.lipsync_object.end_frame) and not self.is_moving:
+                            self.x() + event.x())) >= self.lipsync_object.end_frame - 2 ) and not self.is_moving:
                         self.is_resizing = True
                         self.resize_origin = 1
+                    if ( self.convert_to_frames(self.x() + event.x()) <= self.convert_to_frames(self.x()) + 2 ):       
+                        self.is_resizing = True
+                        self.resize_origin = 0
                 else:
                     self.is_resizing = False
                     self.is_moving = True
@@ -299,13 +303,13 @@ class MovableButton(QtWidgets.QPushButton):
                             self.wfv_parent.doc.dirty = True
                             self.resize(self.convert_to_pixels(self.lipsync_object.end_frame) -
                                         self.convert_to_pixels(self.lipsync_object.start_frame), self.height())
-                # elif self.resize_origin == 0:  # start resize from left side
-                #     if round(self.convert_to_frames(event.x() + self.x())) < self.lipsync_object.end_frame:
-                #         if round(self.convert_to_frames(event.x() + self.x())) >= self.get_left_max():
-                #             self.lipsync_object.start_frame = round(self.convert_to_frames(event.x() + self.x()))
-                #             new_length = self.convert_to_pixels(self.lipsync_object.end_frame) - self.convert_to_pixels(self.lipsync_object.start_frame)
-                #             self.resize(new_length, self.height())
-                #             self.move(self.convert_to_pixels(self.lipsync_object.start_frame), self.y())
+                elif self.resize_origin == 0:  # start resize from left side
+                    if round(self.convert_to_frames(event.x() + self.x())) < self.lipsync_object.end_frame:
+                        if round(self.convert_to_frames(event.x() + self.x())) >= self.get_left_max():
+                            self.lipsync_object.start_frame = round(self.convert_to_frames(event.x() + self.x()))
+                            new_length = self.convert_to_pixels(self.lipsync_object.end_frame) - self.convert_to_pixels(self.lipsync_object.start_frame)
+                            self.resize(new_length, self.height())
+                            self.move(self.convert_to_pixels(self.lipsync_object.start_frame), self.y())
             else:
                 self.is_moving = True
                 mime_data = QtCore.QMimeData()

--- a/WaveformViewRewrite.py
+++ b/WaveformViewRewrite.py
@@ -287,8 +287,8 @@ class MovableButton(QtWidgets.QPushButton):
             if self.is_resizing and not self.is_moving:
                 self.wfv_parent.doc.dirty = True
                 if self.resize_origin == 1:  # start resize from right side
-                    if round(self.convert_to_frames(
-                             event.x() + self.x())) >= self.lipsync_object.start_frame + self.get_min_size():
+                    if self.convert_to_frames(
+                             event.x() + self.x()) >= self.lipsync_object.start_frame + self.get_min_size():
                         if self.convert_to_frames(event.x() + self.x()) <= self.get_right_max():
                             self.lipsync_object.end_frame = math.ceil(self.convert_to_frames(event.x() + self.x()))
                             self.wfv_parent.doc.dirty = True


### PR DESCRIPTION
This commit enables resizing word boxes from both sides and adds some logic to make it work. 
What was the reason to disable it in the past?

I also modified the file export dialog for MOHO to suggest a filename with .dat at the end or add .dat, if no other filetype is specified by the user.

Tested on macOS 10.15.7.