### PR TITLE
Fix trivial comment typos

### DIFF
--- a/SoundPlayer.py
+++ b/SoundPlayer.py
@@ -157,5 +157,5 @@ class SoundPlayer:
         thread.start_new_thread(self._play, (0, self.Duration()))
 
     def play_segment(self, start, length):
-        if not self.isplaying:  # otherwise this get's kinda echo-y
+        if not self.isplaying:  # otherwise this gets kinda echo-y
             thread.start_new_thread(self._play, (start, length))

--- a/SoundPlayerNew.py
+++ b/SoundPlayerNew.py
@@ -122,7 +122,7 @@ class SoundPlayer:
 
     def play_segment(self, start, length):
         print("Playing Segment")
-        if not self.isplaying:  # otherwise this get's kinda echo-y
+        if not self.isplaying:  # otherwise this gets kinda echo-y
             self.isplaying = True
             self.audio.setPosition(start * 1000.0)
             self.audio.play()

--- a/SoundPlayerOSX.py
+++ b/SoundPlayerOSX.py
@@ -131,7 +131,7 @@ class SoundPlayer:
 
     def play_segment(self, start, length):
         print("Playing Segment")
-        if not self.isplaying:  # otherwise this get's kinda echo-y
+        if not self.isplaying:  # otherwise this gets kinda echo-y
             self.isplaying = True
             self.audio.setPosition(start * 1000.0)
             self.audio.play()

--- a/SoundPlayerQT.py
+++ b/SoundPlayerQT.py
@@ -147,7 +147,7 @@ class SoundPlayer:
         self.audio.play()
 
     def play_segment(self, start, length):
-        if not self.is_playing():  # otherwise this get's kinda echo-y
+        if not self.is_playing():  # otherwise this gets kinda echo-y
             self.isplaying = True
             self.audio.setPosition(start * 1000.0)
             self.audio.play()

--- a/WaveformViewQT.py
+++ b/WaveformViewQT.py
@@ -291,7 +291,7 @@ class MovableButton(QtWidgets.QPushButton):
         # if next_one:
         #     print("Next one: " + next_one.text)
         #     print(dir(next_one))
-        # We should now have the previous and next object and it's parent here.
+        # We should now have the previous and next object and its parent here.
 
         self.left_edge = 0
         self.right_edge = 0


### PR DESCRIPTION
Found via `codespell -q 3 -S ./rsrc/languages/default  --builtin=clear,rare,code -L ba,datas,dur,nd`