### PR TITLE
Script for generating Linux AppImage package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ ffmpeg.exe
 
 venv/
 /build/linux-appimage/build
+/build/linux-appimage/*.AppImage
 /dist/
 /.github/
 /output/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ ffmpeg.exe
 .idea/
 
 venv/
-/build/
+/build/linux-appimage/build
 /dist/
 /.github/
 /output/

--- a/build/linux-appimage/build.sh
+++ b/build/linux-appimage/build.sh
@@ -28,17 +28,15 @@ wget "${PYTHON_APPIMAGE_URL}"
 chmod +x "${PYTHON_APPIMAGE_FILENAME}"
 "./${PYTHON_APPIMAGE_FILENAME}" --appimage-extract
 
-export PATH="$(pwd)/squashfs-root/usr/bin:$PATH"
-
-pip install sounddevice
-pip install numpy
-pip install pydub
-pip install anytree
-pip install PySide2
-pip install audioread
-#pip install allosaurus
-pip install appdirs
-pip install pyyaml
+./squashfs-root/AppRun -m pip install sounddevice
+./squashfs-root/AppRun -m pip install numpy
+./squashfs-root/AppRun -m pip install pydub
+./squashfs-root/AppRun -m pip install anytree
+./squashfs-root/AppRun -m pip install PySide2
+./squashfs-root/AppRun -m pip install audioread
+#./squashfs-root/AppRun -m pip install allosaurus
+./squashfs-root/AppRun -m pip install appdirs
+./squashfs-root/AppRun -m pip install pyyaml
 
 
 #find "${SOURCES_DIR}" -type f -not -iname '*/not-from-here/*' -exec cp -rf '{}' '/dest/{}' ';'

--- a/build/linux-appimage/build.sh
+++ b/build/linux-appimage/build.sh
@@ -14,13 +14,13 @@ YUM=$(which yum 2>/dev/null)
 APT_GET=$(which apt-get 2>/dev/null)
 
 echo "Installing required build tools."
+# libffi is required by cffi python package, which in turn is required by sounddevice
 if [[ ! -z $YUM ]]; then
     sudo yum install -y gcc libffi-devel
 elif [[ ! -z $APT_GET ]]; then
     sudo apt-get install -y build-essential libffi-dev
 fi
 
-#? libffi
 
 [ -d "${SCRIPTPATH}/build" ] || mkdir -p "${SCRIPTPATH}/build"
 cd "${SCRIPTPATH}/build"

--- a/build/linux-appimage/build.sh
+++ b/build/linux-appimage/build.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# https://github.com/AppImage/AppImageKit/wiki/Bundling-Python-apps
+
+SCRIPTPATH=$(cd `dirname "$0"`; pwd)
+SOURCES_DIR="${SCRIPTPATH}/../../"
+
+#PYTHON_APPIMAGE_URL="https://github.com/niess/python-appimage/releases/download/python3.10/python3.10.0-cp310-cp310-manylinux2010_x86_64.AppImage"
+PYTHON_APPIMAGE_URL="https://github.com/niess/python-appimage/releases/download/python3.7/python3.7.11-cp37-cp37m-manylinux2010_x86_64.AppImage"
+PYTHON_APPIMAGE_FILENAME=`basename "${PYTHON_APPIMAGE_URL}"`
+
+# Detect package management system.
+YUM=$(which yum 2>/dev/null)
+APT_GET=$(which apt-get 2>/dev/null)
+
+echo "Installing required build tools."
+if [[ ! -z $YUM ]]; then
+    sudo yum install -y gcc libffi-devel
+elif [[ ! -z $APT_GET ]]; then
+    sudo apt-get install -y build-essential libffi-dev
+fi
+
+#? libffi
+
+[ -d "${SCRIPTPATH}/build" ] || mkdir -p "${SCRIPTPATH}/build"
+cd "${SCRIPTPATH}/build"
+wget "${PYTHON_APPIMAGE_URL}"
+chmod +x "${PYTHON_APPIMAGE_FILENAME}"
+"./${PYTHON_APPIMAGE_FILENAME}" --appimage-extract
+
+export PATH="$(pwd)/squashfs-root/usr/bin:$PATH"
+
+pip install sounddevice
+pip install numpy
+pip install pydub
+pip install anytree
+pip install PySide2
+pip install audioread
+#pip install allosaurus
+pip install appdirs
+pip install pyyaml
+
+
+#find "${SOURCES_DIR}" -type f -not -iname '*/not-from-here/*' -exec cp -rf '{}' '/dest/{}' ';'
+rsync -av --progress "${SOURCES_DIR}" "squashfs-root/opt/papagayo-ng" --exclude build
+
+cp "${SCRIPTPATH}/files/papagayo-ng" squashfs-root/usr/bin/
+rm squashfs-root/usr/share/applications/*.desktop
+rm squashfs-root/*.desktop
+cp "${SCRIPTPATH}/files/papagayo-ng.desktop" squashfs-root/usr/share/applications/
+cp "${SCRIPTPATH}/files/papagayo-ng.desktop" squashfs-root/
+cp "${SOURCES_DIR}/rsrc/papagayo-ng.png" squashfs-root/
+rm squashfs-root/usr/share/metainfo/*
+
+# Change AppRun so that it launches papagayo-ng
+sed -i -e 's|/opt/python3.7/bin/python3.7|/usr/bin/papagayo-ng|g' ./squashfs-root/AppRun
+
+# Convert back into an AppImage
+wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+chmod +x appimagetool-*.AppImage
+# 
+# The following line does not work quite yet due to https://github.com/probonopd/go-appimage/issues/30
+# ./appimagetool-*-x86_64.AppImage deploy squashfs-root/usr/share/applications/taguette.desktop
+./appimagetool-*-x86_64.AppImage squashfs-root/ # Replace "1" with the actual version/build number
+mv Papagayo_NG-*-x86_64.AppImage ../
+cd ..
+rm -rf build

--- a/build/linux-appimage/build.sh
+++ b/build/linux-appimage/build.sh
@@ -28,15 +28,9 @@ wget "${PYTHON_APPIMAGE_URL}"
 chmod +x "${PYTHON_APPIMAGE_FILENAME}"
 "./${PYTHON_APPIMAGE_FILENAME}" --appimage-extract
 
-./squashfs-root/AppRun -m pip install sounddevice
-./squashfs-root/AppRun -m pip install numpy
-./squashfs-root/AppRun -m pip install pydub
-./squashfs-root/AppRun -m pip install anytree
-./squashfs-root/AppRun -m pip install PySide2
-./squashfs-root/AppRun -m pip install audioread
-#./squashfs-root/AppRun -m pip install allosaurus
-./squashfs-root/AppRun -m pip install appdirs
-./squashfs-root/AppRun -m pip install pyyaml
+
+#./squashfs-root/AppRun -m pip install -r "${SOURCES_DIR}requirements.txt"
+./squashfs-root/AppRun -m pip install $(grep -ivE "allosaurus" "${SOURCES_DIR}requirements.txt")
 
 
 #find "${SOURCES_DIR}" -type f -not -iname '*/not-from-here/*' -exec cp -rf '{}' '/dest/{}' ';'

--- a/build/linux-appimage/build.sh
+++ b/build/linux-appimage/build.sh
@@ -28,9 +28,10 @@ wget "${PYTHON_APPIMAGE_URL}"
 chmod +x "${PYTHON_APPIMAGE_FILENAME}"
 "./${PYTHON_APPIMAGE_FILENAME}" --appimage-extract
 
-
-#./squashfs-root/AppRun -m pip install -r "${SOURCES_DIR}requirements.txt"
-./squashfs-root/AppRun -m pip install $(grep -ivE "allosaurus" "${SOURCES_DIR}requirements.txt")
+#export PATH="$(pwd)/squashfs-root/usr/bin:$PATH"
+./squashfs-root/AppRun -m pip install torch==1.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+./squashfs-root/AppRun -m pip install -r "${SOURCES_DIR}requirements.txt"
+#./squashfs-root/AppRun -m pip install $(grep -ivE "allosaurus" "${SOURCES_DIR}requirements.txt")
 
 
 #find "${SOURCES_DIR}" -type f -not -iname '*/not-from-here/*' -exec cp -rf '{}' '/dest/{}' ';'

--- a/build/linux-appimage/files/papagayo-ng
+++ b/build/linux-appimage/files/papagayo-ng
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd `dirname "$0"`; pwd)
+cd "$SCRIPT_DIR/../../opt/papagayo-ng"
+"$SCRIPT_DIR/python" ./papagayo-ng.py "$@"

--- a/build/linux-appimage/files/papagayo-ng.desktop
+++ b/build/linux-appimage/files/papagayo-ng.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Papagayo NG
+Comment=Lipsync tool
+Exec=papagayo-ng
+Icon=papagayo-ng
+Terminal=false
+Type=Application
+Categories=Graphics;Application;
+MimeType=application/x-papagayo;application/x-extension-pgo;
+X-Desktop-File-Install-Version=0.15
+X-AppImage-Version=bf4caf5
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PySide2
 audioread
 allosaurus >= 1.0.1
 appdirs
+pyyaml

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-apt-get install python-pyaudio python-wxgtk2.8


### PR DESCRIPTION
This is a script to generate Linux AppImage package. Just execute `build/linux-appimage/build.sh` script and it will generate package for you.

Here is a sample package generated by this script - [Papagayo_NG-d91a1b7-x86_64.AppImage](https://archive.morevnaproject.org/s/n6z5yEXta9EMkZA)

At the moment the package doesn't includes Allosaurus, as it makes very large package - 1,2 Gb (comparing to ~300 Mb without Allosaurus). You can enable Allosaurus by replacing following line
```
./squashfs-root/AppRun -m pip install $(grep -ivE "allosaurus" "${SOURCES_DIR}requirements.txt")
```
to this one
```
./squashfs-root/AppRun -m pip install -r "${SOURCES_DIR}requirements.txt"
```

Have fun! ^__^