### PR TITLE
To have a cleaner build we now use the prepare_appimage_build_dir.py …

### DIFF
--- a/papagayo-ng.spec
+++ b/papagayo-ng.spec
@@ -108,7 +108,7 @@ shutil.copytree("./phonemes", os.path.join(installer_folder , "phonemes"))
 shutil.copytree("./rsrc", os.path.join(installer_folder , "rsrc"))
 if with_rhubarb:
     shutil.copytree("./rhubarb", os.path.join(installer_folder , "rhubarb"))
-shutil.copy("./papagayo-ng.nsi", os.path.join(installer_folder , "papagayo-ng.nsi"))
+shutil.copy("../papagayo-ng.nsi", os.path.join(installer_folder , "papagayo-ng.nsi"))
 shutil.copy("./papagayo-ng.ico", os.path.join(installer_folder , "papagayo-ng.ico"))
 shutil.copy("./ipa_cmu.json", os.path.join(installer_folder , "ipa_cmu.json"))
 shutil.copy("./version_information.txt", os.path.join(installer_folder , "version_information.txt"))

--- a/prepare_appimage_build_dir.py
+++ b/prepare_appimage_build_dir.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 
+PREPARE_FOR_PYINSTALLER = True
+
 
 def main():
     source_dir = os.getcwd()
@@ -17,9 +19,13 @@ def main():
                      "WaveformViewRewrite.py", "papagayongrcc.py",
                      "LipsyncDoc.py", "LipsyncFrameQT.py",
                      "auto_recognition.py", "SoundPlayer.py", "gpl.txt",
-                     "papagayo-ng.ico", "ipa_cmu.json", "version_information.txt", "file_version_info.txt",
+                     "papagayo-ng.ico", "ipa_cmu.json", "version_information.txt",
                      "qt-icons.qrc", "readme.md", "about_markdown.html",
                      "rsrc/", "breakdowns/", "phonemes/", "requirements.txt"]
+
+    if PREPARE_FOR_PYINSTALLER:
+        list_of_files.append("nsis_extra_files/")
+        list_of_files.append("papagayo-ng.spec")
 
     for file_name in list_of_files:
         if file_name.endswith(r"/"):

--- a/version_information.txt
+++ b/version_information.txt
@@ -1,4 +1,4 @@
-Version: 1.6.4.0
+Version: 1.6.4.1
 CompanyName: Morevna Project
 FileDescription: Lip-Sync Software
 InternalName: Papagayo-NG


### PR DESCRIPTION
…file to also prepare a clean folder for the PyInstaller build.

The .spec file also has been adjusted to reflect that.